### PR TITLE
fix: 修复 HTTP 图片上传和视频相对地址解析

### DIFF
--- a/backend/video-protocols.js
+++ b/backend/video-protocols.js
@@ -160,6 +160,30 @@ function getVideoPollPath(protocol, taskId) {
 }
 
 /**
+ * 将上游视频结果地址解析为可供服务端下载的绝对 HTTP(S) 地址。
+ *
+ * 上游兼容服务可能返回完整 URL，也可能只返回以 /v1 开头的站内路径，
+ * 甚至返回不带开头斜杠的相对路径。完整 URL 保持原样；路径形式统一基于
+ * 配置的 Base URL 解析，避免把相对路径直接传给 Node.js 的 URL 构造器。
+ *
+ * @param {string} remoteUrl 上游返回的视频地址。
+ * @param {string} baseUrl 用户配置并已规范化的上游基础地址。
+ * @returns {string} 可供 fetch 使用的绝对视频地址。
+ */
+function resolveVideoRemoteUrl(remoteUrl, baseUrl) {
+  const value = String(remoteUrl || '').trim();
+  if (!value) return '';
+
+  try {
+    return new URL(value).toString();
+  } catch {
+    const base = new URL(String(baseUrl || '').trim());
+    const path = value.startsWith('/') ? value : `/${value}`;
+    return new URL(path, base.origin).toString();
+  }
+}
+
+/**
  * 规范化三种协议的任务状态与结果下载地址。
  * @param {'new-api' | 'openai' | 'xai' | 'legacy-openai-video'} protocol 视频协议。
  * @param {Record<string, any>} data 上游任务响应。
@@ -173,7 +197,7 @@ function normalizeVideoPollResult(protocol, data, baseUrl, taskId) {
 
   // 不论请求协议为何，优先识别第三方兼容服务常见的两种直接结果地址。
   const remoteUrl = [data?.video?.url, data?.url].find(value => typeof value === 'string' && value.trim());
-  if (remoteUrl) return { state: 'completed', remoteUrl: remoteUrl.trim() };
+  if (remoteUrl) return { state: 'completed', remoteUrl: resolveVideoRemoteUrl(remoteUrl, baseUrl) };
 
   // OpenAI 官方完成态不返回结果 URL，需要通过同一任务的 content 端点下载。
   if (status === 'completed' && protocol === 'openai') {
@@ -191,4 +215,5 @@ module.exports = {
   getVideoPollPath,
   isVideoProtocol,
   normalizeVideoPollResult,
+  resolveVideoRemoteUrl,
 };

--- a/frontend/src/lib/__tests__/video-protocols.test.ts
+++ b/frontend/src/lib/__tests__/video-protocols.test.ts
@@ -11,6 +11,7 @@ const {
   getVideoDownloadHeaders,
   getVideoPollPath,
   normalizeVideoPollResult,
+  resolveVideoRemoteUrl,
 } = loadCommonJs(path.resolve(testDir, '../../../../backend/video-protocols.js'));
 
 const request = {
@@ -95,6 +96,15 @@ describe('视频协议适配器', () => {
     expect(getCreatedVideoTaskId('xai', { request_id: 'native-id', id: 'compatible-id' })).toBe('native-id');
     expect(getCreatedVideoTaskId('new-api', { task_id: 'native-id', id: 'compatible-id' })).toBe('native-id');
     expect(getCreatedVideoTaskId('openai', { id: '   ' })).toBe('');
+  });
+
+  it('将上游返回的绝对、根相对和普通相对视频地址统一解析为绝对地址', () => {
+    expect(resolveVideoRemoteUrl('https://cdn.example/video.mp4', 'https://api.example/v1')).toBe('https://cdn.example/video.mp4');
+    expect(resolveVideoRemoteUrl('/v1/videos/task/content', 'https://api.example/v1')).toBe('https://api.example/v1/videos/task/content');
+    expect(normalizeVideoPollResult('xai', { status: 'done', video: { url: '/v1/videos/task/content' } }, 'https://api.example', 'task')).toEqual({
+      state: 'completed',
+      remoteUrl: 'https://api.example/v1/videos/task/content',
+    });
   });
 
   it('轮询响应跨协议兼容直接视频地址并统一识别失败状态', () => {

--- a/frontend/src/lib/upload-image-cache.ts
+++ b/frontend/src/lib/upload-image-cache.ts
@@ -89,9 +89,56 @@ function bufferToHex(buffer: ArrayBuffer): string {
         .join('');
 }
 
+/**
+ * 计算上传文件的稳定缓存键。
+ *
+ * 优先使用 Web Crypto 的 SHA-256；但 Web Crypto 的 subtle API 在通过普通 HTTP
+ * 访问的非安全上下文中可能不存在。图片上传本身不应依赖 HTTPS，因此在该能力
+ * 不可用或调用失败时，改用双路 32 位 FNV-1a 内容哈希作为缓存键。这个降级哈希
+ * 只用于本地上传缓存和重复文件去重，不用于安全校验、签名或权限判断。
+ *
+ * @param file 待计算缓存键的本地图片文件。
+ * @returns 稳定的十六进制缓存键。
+ */
 async function hashFile(file: File): Promise<string> {
-    const digest = await crypto.subtle.digest('SHA-256', await file.arrayBuffer());
-    return bufferToHex(digest);
+    const buffer = await file.arrayBuffer();
+    const subtle = typeof crypto !== 'undefined' ? crypto.subtle : undefined;
+
+    if (subtle) {
+        try {
+            const digest = await subtle.digest('SHA-256', buffer);
+            return bufferToHex(digest);
+        } catch {
+            // 非安全上下文、浏览器策略或运行时实现异常时继续使用本地降级哈希。
+        }
+    }
+
+    return `fallback-${hashBytesForCache(new Uint8Array(buffer))}`;
+}
+
+/**
+ * 在 Web Crypto 不可用时，使用两路 FNV-1a 计算本地缓存专用内容哈希。
+ *
+ * 两个独立的 32 位状态共同组成 64 位十六进制结果，避免把缓存能力绑定到
+ * 安全上下文。每一步都使用 Math.imul 保持 32 位整数乘法语义，避免 JavaScript
+ * 浮点数在大文件遍历时丢失低位信息。
+ *
+ * @param bytes 文件的完整二进制内容。
+ * @returns 由两路 32 位状态拼成的十六进制哈希。
+ */
+function hashBytesForCache(bytes: Uint8Array): string {
+    let first = 0x811c9dc5;
+    let second = 0x9e3779b1;
+
+    for (const byte of bytes) {
+        first = Math.imul(first ^ byte, 0x01000193);
+        second = Math.imul(second ^ byte, 0x01000193);
+    }
+
+    first = Math.imul(first ^ bytes.length, 0x01000193);
+    second = Math.imul(second ^ bytes.length, 0x01000193);
+
+    return `${(first >>> 0).toString(16).padStart(8, '0')}${(second >>> 0).toString(16).padStart(8, '0')}`;
 }
 
 function readFileAsDataUrl(file: Blob): Promise<string> {


### PR DESCRIPTION
- 图片上传不再硬依赖非安全上下文中的 crypto.subtle，HTTP 部署时自动使用本地降级哈希完成缓存去重。
- 视频轮询结果支持绝对 URL、根相对路径和普通相对路径，避免完成任务在本地缓存阶段因 Invalid URL 被误判失败。
- 增加视频相对地址解析回归测试，覆盖上游 Base URL 带 /v1 的场景。